### PR TITLE
feat: Allow passing PR title as arg to skip API request

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,12 @@ jobs:
 
 ## Arguments
 
-| Argument              | Required | Example                   | Purpose                                                                                                                                   |
-| --------------------- | -------- | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `commitlintRulesPath` | No       | `'./commitlint.rules.js'` | A relative path from the repo root to a file containing custom Commitlint rules to override the default ([docs](#customising-lint-rules)) |
-| `scopeRegex`          | No       | `'[A-Z]+-[0-9]+'`         | A JS regex (without slashes or flags) used to lint the PR scope ([docs](#linting-scope))                                                  |
-| `enforcedScopeTypes`  | No       | `'feat\|fix'`             | A list of PR types where the scope is always required and linted ([docs](#skipping-scope-linting))                                        |
+| Argument              | Required | Example                                  | Purpose                                                                                                                                   |
+| --------------------- | -------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `prTitle`             | No       | `${{ github.event.pull_request.title }}` | The title of the pull request if not using a Github token ([docs](#arguments-vs-api-for-pr-title))                                        |
+| `commitlintRulesPath` | No       | `'./commitlint.rules.js'`                | A relative path from the repo root to a file containing custom Commitlint rules to override the default ([docs](#customising-lint-rules)) |
+| `scopeRegex`          | No       | `'[A-Z]+-[0-9]+'`                        | A JS regex (without slashes or flags) used to lint the PR scope ([docs](#linting-scope))                                                  |
+| `enforcedScopeTypes`  | No       | `'feat\|fix'`                            | A list of PR types where the scope is always required and linted ([docs](#skipping-scope-linting))                                        |
 
 ## Usage
 
@@ -54,6 +55,17 @@ If you do not use this setting in your repo, Github will by default use the titl
 You can find the option in the root General settings of your Github repo.
 
 > Pull Requests > Allow Squash Merging > Default Commit Message > Pull Request Title
+
+### Arguments vs. API for PR title
+
+The action allows you to provide the PR title in two ways. You can either include `GITHUB_TOKEN` as an environment variable, which will use the Github API to retrieve the title of the PR, or you can manually pass the title of the pull request as an argument.
+
+```yaml
+with:
+  prTitle: ${{ github.event.pull_request.title }}
+```
+
+If a `prTitle` arg is provided, the API request will be skipped. This can be useful to avoid API rate limiting with shared Github access tokens.
 
 ### Customising lint rules
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ jobs:
 
 | Argument              | Required | Example                                  | Purpose                                                                                                                                   |
 | --------------------- | -------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `prTitle`             | No       | `${{ github.event.pull_request.title }}` | The title of the pull request if not using a Github token ([docs](#arguments-vs-api-for-pr-title))                                        |
+| `prTitle`             | No       | `${{ github.event.pull_request.title }}` | The title of the pull request if not using a Github token ([docs](#providing-a-pr-title))                                                 |
 | `commitlintRulesPath` | No       | `'./commitlint.rules.js'`                | A relative path from the repo root to a file containing custom Commitlint rules to override the default ([docs](#customising-lint-rules)) |
 | `scopeRegex`          | No       | `'[A-Z]+-[0-9]+'`                        | A JS regex (without slashes or flags) used to lint the PR scope ([docs](#linting-scope))                                                  |
 | `enforcedScopeTypes`  | No       | `'feat\|fix'`                            | A list of PR types where the scope is always required and linted ([docs](#skipping-scope-linting))                                        |
@@ -56,7 +56,7 @@ You can find the option in the root General settings of your Github repo.
 
 > Pull Requests > Allow Squash Merging > Default Commit Message > Pull Request Title
 
-### Arguments vs. API for PR title
+### Providing a PR title
 
 The action allows you to provide the PR title in two ways. You can either include `GITHUB_TOKEN` as an environment variable, which will use the Github API to retrieve the title of the PR, or you can manually pass the title of the pull request as an argument.
 

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ runs:
   using: 'node20'
   main: 'dist/index.js'
 inputs:
+  prTitle:
+    description: 'Manually provide a PR title as an arg to skip making an API request, using ${{ github.event.pull_request.title }}'
+    required: false
   commitlintRulesPath:
     description: 'Relative path to commitlint rules file'
     required: false

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -38,15 +38,15 @@ const lint = async (
   enforcedScopeTypes?: Array<string>,
   scopeRegex?: RegExp
 ) => {
-  if (!githubToken) {
-    return setFailedMissingToken();
-  }
-
   let pullRequestTitle = prTitle;
 
   if (pullRequestTitle) {
     logPrTitleFoundArg(pullRequestTitle);
   } else {
+    if (!githubToken) {
+      return setFailedMissingToken();
+    }
+
     const octokit = github.getOctokit(githubToken);
 
     if (!github.context.payload.pull_request) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,12 +6,13 @@ try {
   const {
     githubToken,
     githubWorkspace,
+    prTitle,
     rulesPath,
     enforcedScopeTypes,
-    scopeRegex
+    scopeRegex,
   } = getActionConfig();
 
-  lint(githubToken, githubWorkspace, rulesPath, enforcedScopeTypes, scopeRegex);
+  lint(githubToken, githubWorkspace, prTitle, rulesPath, enforcedScopeTypes, scopeRegex);
 } catch (e) {
   core.setFailed(`Failed to run action with error: ${e}`);
 }

--- a/src/outputs/logs.test.ts
+++ b/src/outputs/logs.test.ts
@@ -5,7 +5,8 @@ import {
   logLintableScopeFound,
   logLintingPrTitle,
   logLintingPrTitleWithCustomRules,
-  logPrTitleFound,
+  logPrTitleFoundArg,
+  logPrTitleFoundApi,
   logScopeCheckSkipped
 } from './logs';
 
@@ -24,10 +25,17 @@ describe('Log outputs', () => {
     vi.resetAllMocks();
   });
 
-  it('`logPrTitleFound` should pass the expected log to the output', () => {
-    logPrTitleFound(`fix(CDV-2812): Get with friends`);
+  it('`logPrTitleFoundArg` should pass the expected log to the output', () => {
+    logPrTitleFoundArg(`fix(CDV-2812): Get with friends`);
     expect(info).toHaveBeenCalledWith(
-      `🕵️ Found PR title: "fix(CDV-2812): Get with friends"`
+      `🕵️ Found PR title in action args: "fix(CDV-2812): Get with friends"`
+    );
+  });
+
+  it('`logPrTitleFoundApi` should pass the expected log to the output', () => {
+    logPrTitleFoundApi(`fix(CDV-2812): Get with friends`);
+    expect(info).toHaveBeenCalledWith(
+      `🕵️ Found PR title from Github API: "fix(CDV-2812): Get with friends"`
     );
   });
 

--- a/src/outputs/logs.ts
+++ b/src/outputs/logs.ts
@@ -1,8 +1,11 @@
 import * as core from '@actions/core';
 import { Commit } from 'conventional-commits-parser';
 
-export const logPrTitleFound = (title: string) =>
-  core.info(`🕵️ Found PR title: "${title}"`);
+export const logPrTitleFoundArg = (title: string) =>
+  core.info(`🕵️ Found PR title in action args: "${title}"`);
+
+export const logPrTitleFoundApi = (title: string) =>
+  core.info(`🕵️ Found PR title from Github API: "${title}"`);
 
 export const logLintingPrTitle = () =>
   core.info(`📋 Checking PR title with commitlint`);

--- a/src/utils/config.test.ts
+++ b/src/utils/config.test.ts
@@ -8,6 +8,7 @@ describe('Config utils', () => {
     process.env.INPUT_COMMITLINTRULESPATH = './commitlint.rules.js';
     process.env.GITHUB_TOKEN = 'asdf';
     process.env.GITHUB_WORKSPACE = './';
+    process.env.INPUT_PR_TITLE = 'chore(TEST-1234): Manually pass a PR title'
   });
 
   it('`getActionConfig` returns a valid config object with required values', () => {
@@ -15,7 +16,8 @@ describe('Config utils', () => {
     expect(config).toMatchObject({
       rulesPath: expect.any(String),
       githubToken: expect.any(String),
-      githubWorkspace: expect.any(String)
+      githubWorkspace: expect.any(String),
+      prTitle: expect.any(String)
     });
   });
 
@@ -27,7 +29,8 @@ describe('Config utils', () => {
       enforcedScopeTypes: expect.any(Array),
       rulesPath: expect.any(String),
       githubToken: expect.any(String),
-      githubWorkspace: expect.any(String)
+      githubWorkspace: expect.any(String),
+      prTitle: expect.any(String)
     });
     expect(config.enforcedScopeTypes).toEqual(['feat', 'fix']);
   });
@@ -40,7 +43,20 @@ describe('Config utils', () => {
       scopeRegex: expect.any(RegExp),
       rulesPath: expect.any(String),
       githubToken: expect.any(String),
-      githubWorkspace: expect.any(String)
+      githubWorkspace: expect.any(String),
+      prTitle: expect.any(String)
+    });
+  });
+
+  it('`getActionConfig` returns a valid config object with `undefined` PR title if not provided', () => {
+    delete process.env.INPUT_PR_TITLE;
+
+    const config = getActionConfig();
+    expect(config).toMatchObject({
+      rulesPath: expect.any(String),
+      githubToken: expect.any(String),
+      githubWorkspace: expect.any(String),
+      prTitle: undefined
     });
   });
 });

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -23,6 +23,7 @@ export const getActionConfig = () => {
   return {
     githubToken: process.env.GITHUB_TOKEN,
     githubWorkspace: process.env.GITHUB_WORKSPACE,
+    prTitle: process.env.INPUT_PR_TITLE,
     rulesPath: process.env.INPUT_COMMITLINTRULESPATH,
     ...(enforcedScopeTypes ? { enforcedScopeTypes } : {}),
     ...(scopeRegex ? { scopeRegex } : {})


### PR DESCRIPTION
Allow users to pass the title of the PR as an arg in the action config to skip requiring an API request to retrieve the title, avoiding any risk of rate limiting.

### Usage
```yml
- name: Lint PR Title
  uses: benhodgson87/conventional-pull-request-action@v1
  with:
    prTitle: ${{ github.event.pull_request.title }}
```