### PR TITLE
test: cover slashed scopes listed verbatim in scope-enum

### DIFF
--- a/src/fixtures/commitlint.scope-enum.rules.js
+++ b/src/fixtures/commitlint.scope-enum.rules.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'scope-enum': [2, 'always', ['feat/auth', 'core/logger', 'utils']]
+  }
+};

--- a/src/lint.test.ts
+++ b/src/lint.test.ts
@@ -323,6 +323,59 @@ describe('Linter', () => {
     expect(setFailed).not.toHaveBeenCalled();
   });
 
+  it('should pass if a slashed scope is listed verbatim in scope-enum', async () => {
+    mocks.getOctokit.mockReturnValue({
+      rest: {
+        pulls: {
+          get: vi.fn().mockReturnValue({
+            data: {
+              commits: 1,
+              title: 'feat(feat/auth): subject is valid'
+            }
+          })
+        }
+      }
+    });
+
+    await lint.apply(null, [
+      'TOKEN',
+      './',
+      './src/fixtures/commitlint.scope-enum.rules.js'
+    ]);
+
+    expect(info).toHaveBeenLastCalledWith('✅ PR title validated successfully');
+    expect(error).not.toHaveBeenCalled();
+    expect(setFailed).not.toHaveBeenCalled();
+  });
+
+  it('should fail if a slashed scope is not listed in scope-enum', async () => {
+    mocks.getOctokit.mockReturnValue({
+      rest: {
+        pulls: {
+          get: vi.fn().mockReturnValue({
+            data: {
+              commits: 1,
+              title: 'feat(feat/unknown): subject is valid'
+            }
+          })
+        }
+      }
+    });
+
+    await lint.apply(null, [
+      'TOKEN',
+      './',
+      './src/fixtures/commitlint.scope-enum.rules.js'
+    ]);
+
+    expect(error).toHaveBeenCalledWith(
+      '⛔️ Commitlint: scope must be one of [feat/auth, core/logger, utils]'
+    );
+    expect(setFailed).toHaveBeenCalledWith(
+      '🛑 Pull request title does not conform to the conventional commit spec'
+    );
+  });
+
   it('should fail if the title is a valid conventional commit but scope is missing for a required type', async () => {
     mocks.getOctokit.mockReturnValue({
       rest: {


### PR DESCRIPTION
## Summary

Adds regression tests for the `scope-enum` rule against slashed scopes that are listed verbatim in the enum (e.g. `scopes: ['feat/auth']` accepting a title `feat(feat/auth): ...`).

## Background

`@commitlint/rules` < 19.5.0 split the title's scope on `/` (and `\`, `,`) and required **every** segment to be in the enum, so a config with `scopes: ['feat/auth']` rejected `feat(feat/auth): ...` because `split('/')` yielded `['feat', 'auth']` and neither token was in the enum.

Upstream fixed this in [`@commitlint/rules@19.5.0`](https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/rules/CHANGELOG.md) ([commitlint PR #4380](https://github.com/conventional-changelog/commitlint/pull/4380)) with a fallback that also accepts the full scope string when it matches the enum verbatim:

```js
isValid = messageScopes.every(isScopeInEnum) || isScopeInEnum(scope);
```

When this PR was originally opened the action shipped `@commitlint/rules@19.0.3` in the lockfile and bundled `dist/`, so it still rejected those scopes. #24 (Node 24 runtime bump) has since refreshed the lockfile and `dist/`, which incidentally pulled in the fix — verifiable on `main` with `grep -A 18 'const scopeEnum' dist/index.js`.

So nothing in `dist/` or `package-lock.json` needs to change here; this PR is now purely the regression coverage.

## What this PR does

- Adds `src/fixtures/commitlint.scope-enum.rules.js` declaring `scopes: ['feat/auth', 'core/logger', 'utils']`.
- Adds two cases in `src/lint.test.ts`:
  - a slashed scope listed verbatim in `scope-enum` is accepted;
  - a slashed scope that isn't listed still fails.

## Test plan

- [x] `npx vitest run` — 37/37 pass