### PR TITLE
fix: Await lint() to ensure errors are caught correctly

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2,16 +2,24 @@ import core from '@actions/core';
 import { lint } from './lint';
 import { getActionConfig } from './utils/config';
 
-try {
-  const {
-    githubToken,
-    githubWorkspace,
-    rulesPath,
-    enforcedScopeTypes,
-    scopeRegex
-  } = getActionConfig();
+(async () => {
+  try {
+    const {
+      githubToken,
+      githubWorkspace,
+      rulesPath,
+      enforcedScopeTypes,
+      scopeRegex
+    } = getActionConfig();
 
-  lint(githubToken, githubWorkspace, rulesPath, enforcedScopeTypes, scopeRegex);
-} catch (e) {
-  core.setFailed(`Failed to run action with error: ${e}`);
-}
+    await lint(
+      githubToken,
+      githubWorkspace,
+      rulesPath,
+      enforcedScopeTypes,
+      scopeRegex
+    );
+  } catch (e) {
+    core.setFailed(`Failed to run action with error: ${e}`);
+  }
+})();


### PR DESCRIPTION
Unhandled promise rejections from async errors inside `lint()` were not being caught by the surrounding `try/catch`. Wrapping in an async IIFE ensures all errors propagate to `core.setFailed` as intended.